### PR TITLE
readme: clarify physical RAM amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Running Arch Linux ARM on the Steam Link.  
 Yes, *running* - no puny chroot.  
 
-The Steam Link has ~256MiB of RAM (unlike what Wikipedia says),  
+The Steam Link has 512 MiB of physical RAM (with 256 permanently reserved for graphical subsystems by the vendor; upstream devicetree makes all 512 available to Linux),  
 and a Marvell ARMv7 CPU (1 Core, 1 Thread) (`MV88DE3108`).  
 
 Directly booting a custom image has been made [/harder/](https://github.com/ValveSoftware/steamlink-sdk/issues/5) due to contractual requirements.  


### PR DESCRIPTION
This repo got cited on Wikipedia as the source for the claim that Link has 256 megs of RAM, so let's clarify what's going on. [wikidevi](https://wikidevi.wi-cat.ru/Valve_Steam_Link_(Model_1003)) lists the exact DRAM chip used.